### PR TITLE
Allow empty scopes in AuthorizationCodeFlow

### DIFF
--- a/src/async_spotify/authentification/authorization_flows/authorization_code_flow.py
+++ b/src/async_spotify/authentification/authorization_flows/authorization_code_flow.py
@@ -62,6 +62,6 @@ class AuthorizationCodeFlow(AuthorizationFlow):
         Returns:
             Are the auth_code_flow valid
         """
-        if self.application_id and self.application_secret and self.redirect_url and self.scopes:
+        if self.application_id and self.application_secret and self.redirect_url:
             return True
         return False


### PR DESCRIPTION
https://github.com/HuiiBuh/AsyncSpotify/issues/31