### PR TITLE
fix body kwargs when make_request

### DIFF
--- a/src/async_spotify/api/_endpoints/library.py
+++ b/src/async_spotify/api/_endpoints/library.py
@@ -89,7 +89,7 @@ class Library(Endpoint):
             kwargs: Optional arguments as keyword args
         """
 
-        return await self.api_request_handler.make_request('GET', URLS.LIBRARY.ALBUMS, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', URLS.LIBRARY.ALBUMS, auth_token, **kwargs)
 
     async def get_shows(self, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> dict:
         """
@@ -103,7 +103,7 @@ class Library(Endpoint):
             kwargs: Optional arguments as keyword args
         """
 
-        return await self.api_request_handler.make_request('GET', URLS.LIBRARY.SHOWS, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', URLS.LIBRARY.SHOWS, auth_token, **kwargs)
 
     async def get_tracks(self, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> dict:
         """
@@ -117,7 +117,7 @@ class Library(Endpoint):
             kwargs: Optional arguments as keyword args
         """
 
-        return await self.api_request_handler.make_request('GET', URLS.LIBRARY.TRACKS, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', URLS.LIBRARY.TRACKS, auth_token, **kwargs)
 
     async def remove_albums(self, album_id_list: List[str], auth_token: SpotifyAuthorisationToken = None) -> None:
         """

--- a/src/async_spotify/api/_endpoints/personalization.py
+++ b/src/async_spotify/api/_endpoints/personalization.py
@@ -37,4 +37,4 @@ class Personalization(Endpoint):
         """
 
         url, _ = self._add_url_params(URLS.PERSONALIZATION.TOP, {'type': content_type})
-        return await self.api_request_handler.make_request('GET', url, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', url, auth_token, **kwargs)

--- a/src/async_spotify/api/_endpoints/player.py
+++ b/src/async_spotify/api/_endpoints/player.py
@@ -52,7 +52,7 @@ class Player(Endpoint):
             The top tracks and artists
         """
 
-        return await self.api_request_handler.make_request('GET', URLS.PLAYER.PLAYER, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', URLS.PLAYER.PLAYER, auth_token, **kwargs)
 
     async def add_to_queue(self, spotify_id: str, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> None:
         """
@@ -111,7 +111,7 @@ class Player(Endpoint):
             The recent tracks
         """
 
-        return await self.api_request_handler.make_request('GET', URLS.PLAYER.RECENTLY, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', URLS.PLAYER.RECENTLY, auth_token, **kwargs)
 
     async def get_current_track(self, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> dict:
         """
@@ -128,7 +128,7 @@ class Player(Endpoint):
             The current track
         """
 
-        return await self.api_request_handler.make_request('GET', URLS.PLAYER.PLAYING, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', URLS.PLAYER.PLAYING, auth_token, **kwargs)
 
     async def pause(self, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> None:
         """
@@ -142,7 +142,7 @@ class Player(Endpoint):
             kwargs: Optional arguments as keyword args
         """
 
-        await self.api_request_handler.make_request('PUT', URLS.PLAYER.PAUSE, kwargs, auth_token)
+        await self.api_request_handler.make_request('PUT', URLS.PLAYER.PAUSE, auth_token, **kwargs)
 
     async def seek(self, position_ms: int, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> None:
         """
@@ -208,7 +208,7 @@ class Player(Endpoint):
             kwargs: Optional arguments as keyword args
         """
 
-        await self.api_request_handler.make_request('POST', URLS.PLAYER.NEXT, kwargs, auth_token)
+        await self.api_request_handler.make_request('POST', URLS.PLAYER.NEXT, auth_token, **kwargs)
 
     async def previous(self, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> None:
         """
@@ -222,7 +222,7 @@ class Player(Endpoint):
             kwargs: Optional arguments as keyword args
         """
 
-        await self.api_request_handler.make_request('POST', URLS.PLAYER.PREVIOUS, kwargs, auth_token)
+        await self.api_request_handler.make_request('POST', URLS.PLAYER.PREVIOUS, auth_token, **kwargs)
 
     async def play(self, device_id: str = None, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> None:
         """

--- a/src/async_spotify/api/_endpoints/playlists.py
+++ b/src/async_spotify/api/_endpoints/playlists.py
@@ -98,7 +98,7 @@ class Playlists(Endpoint):
             A List of Current User's Playlists
         """
 
-        return await self.api_request_handler.make_request('GET', URLS.PLAYLIST.ME, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', URLS.PLAYLIST.ME, auth_token, **kwargs)
 
     async def get_user_all(self, user_id: str, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> dict:
         """
@@ -117,7 +117,7 @@ class Playlists(Endpoint):
         """
 
         url, _ = self._add_url_params(URLS.PLAYLIST.USER, {'user_id': user_id})
-        return await self.api_request_handler.make_request('GET', url, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', url, auth_token, **kwargs)
 
     async def get_one(self, playlist_id: str, auth_token: SpotifyAuthorisationToken = None, **kwargs) -> dict:
         """
@@ -136,7 +136,7 @@ class Playlists(Endpoint):
         """
 
         url, _ = self._add_url_params(URLS.PLAYLIST.ONE, {'playlist_id': playlist_id})
-        return await self.api_request_handler.make_request('GET', url, kwargs, auth_token)
+        return await self.api_request_handler.make_request('GET', url, auth_token, **kwargs)
 
     async def get_cover(self, playlist_id: str, auth_token: SpotifyAuthorisationToken = None) -> dict:
         """

--- a/src/async_spotify/api/_endpoints/shows.py
+++ b/src/async_spotify/api/_endpoints/shows.py
@@ -78,4 +78,4 @@ class Shows(Endpoint):
         url, _ = self._add_url_params(URLS.SHOWS.EPISODES, {'id': show_id})
 
         return await self.api_request_handler.make_request(
-            'GET', url, kwargs, auth_token)
+            'GET', url, auth_token, **kwargs)

--- a/src/async_spotify/api/_endpoints/tracks.py
+++ b/src/async_spotify/api/_endpoints/tracks.py
@@ -113,4 +113,4 @@ class Track(Endpoint):
         url, _ = self._add_url_params(URLS.TRACKS.ONE, {'id': track_id})
 
         return await self.api_request_handler.make_request(
-            'GET', url, kwargs, auth_token)
+            'GET', url, auth_token, **kwargs)


### PR DESCRIPTION
I want to play music with a specific album:
`await api.player.play('c6e56cf6b68c07041768b06e2f29a439e7724b0e', auth_token, body={'context_uri': 'spotify:playlist:37i9dQZF1DWZqd5JICZI0u'})`

It's start to play music, but don't changing album.

kwargs -> **kwargs fix this bug